### PR TITLE
Implement selector widget and add poc

### DIFF
--- a/examples/poc/examples/menu.rs
+++ b/examples/poc/examples/menu.rs
@@ -12,7 +12,7 @@ fn main() -> NcResult<()> {
 
     let mut demo_items = [
         NcMenuItem::new("Restart", NcInput::with_ctrl('r')),
-        NcMenuItem::new("Disabled", NcInput::with_ctrl('d')),
+        NcMenuItem::new("Disabled", NcInput::with_ctrl('🙂')),
     ];
     let mut file_items = [
         NcMenuItem::new("New", NcInput::with_ctrl('n')),
@@ -25,7 +25,7 @@ fn main() -> NcResult<()> {
     let mut help_items = [NcMenuItem::new("About", NcInput::with_ctrl('a'))];
 
     let mut sections = [
-        NcMenuSection::new("Schwarzgerät", &mut demo_items, NcInput::with_alt('ä')),
+        NcMenuSection::new("Demo", &mut demo_items, NcInput::with_alt('a')),
         NcMenuSection::new("File", &mut file_items, NcInput::with_alt('f')),
         NcMenuSection::new_separator(),
         // DEBUG: remove alt modifier for now.
@@ -42,8 +42,8 @@ fn main() -> NcResult<()> {
     let (dim_y, _dim_x) = stdplane.dim_yx();
 
     let menu_top = NcMenu::new(stdplane, mopts)?;
-    menu_top.item_set_status("Schwarzgerät", "Disabled", false)?;
-    menu_top.item_set_status("Schwarzgerät", "Restart", false)?;
+    //menu_top.item_set_status("Schwarzgerät", "Disabled", false)?;
+    //menu_top.item_set_status("Schwarzgerät", "Restart", false)?;
 
     stdplane.set_base("x", 0, NcChannels::from_rgb(0x88aa00, 0x000088))?;
 
@@ -75,7 +75,7 @@ fn main() -> NcResult<()> {
 
 fn run_menu(nc: &mut Nc, menu: &mut NcMenu) -> NcResult<()> {
     // yellow rectangle
-    let planeopts = NcPlaneOptions::new_aligned(10, NcAlign::CENTER, 3, 40);
+    let planeopts = NcPlaneOptions::new_aligned(10, NcAlign::CENTER, 10, 40);
     let stdplane = nc.stdplane();
     let selplane = NcPlane::with_options_bound(stdplane, planeopts)?;
     selplane.set_fg_rgb(0);
@@ -84,6 +84,8 @@ fn run_menu(nc: &mut Nc, menu: &mut NcMenu) -> NcResult<()> {
     channels.set_fg_rgb(0x000088);
     channels.set_bg_rgb(0x88aa00);
     selplane.set_base(" ", 0, channels)?;
+    // Otherwise get crash with puttext
+    selplane.set_scrolling(true);
 
     let mut ni = NcInput::new_empty();
     let mut keypress: char;
@@ -127,10 +129,14 @@ fn run_menu(nc: &mut Nc, menu: &mut NcMenu) -> NcResult<()> {
 
         let mut selni = NcInput::new_empty();
         if let Some(selitem) = menu.selected(Some(&mut selni)) {
-            selplane.putstr_aligned(1, NcAlign::CENTER, &selitem)?;
+            let mut msg = String::new();
+            msg.push_str("Item selected:\n\nDescription: ");
+            msg.push_str(&selitem);
+            msg.push_str("\nInput Id: ");
+            msg.push_str(&selni.id.to_string());
+            selplane.puttext(1, NcAlign::LEFT, &msg)?;
         } else {
-            // DEBUG
-            selplane.putstr_aligned(1, NcAlign::CENTER, "nothing opened")?;
+            selplane.puttext(1, NcAlign::CENTER, "No menu item currently selected")?;
         }
         nc.render()?;
     }

--- a/examples/poc/examples/selector.rs
+++ b/examples/poc/examples/selector.rs
@@ -5,7 +5,7 @@
 //! At all times, exactly one item is selected.
 //!
 //!
-//!01:                                                                        selector widget demo
+//!01:                                                      selector widget demo
 //!02: ╭───────────────────────────────────────────────────────────────────────╮
 //!03: │ this is truly, absolutely an awfully long example of a selector title │
 //!04: ╰─────┬──────────────────────────────pick one (you will die regardless)─┤
@@ -21,18 +21,22 @@
 //!14:
 
 use libnotcurses_sys::{
+    //// Selector:
+    widgets::{NcSelector, NcSelectorItem, NcSelectorOptions},
     // Core
-    Nc, NcResult,
-    // Plane
-    NcPlane, NcPlaneOptions,
+    Nc,
+    NcAlign,
+    NcAlignApi,
+    NcEvType,
+    NcEvTypeApi,
     // Input
-    NcInput, NcKey, NcEvType, NcAlign,
+    NcInput,
+    NcKey,
+    // Plane
+    NcPlane,
+    NcPlaneOptions,
+    NcResult,
 };
-use libnotcurses_sys::*;  // Got a problem with NcAlign
-
-//// Selector:
-use libnotcurses_sys::widgets::{NcSelector, NcSelectorItem, NcSelectorOptions};
-
 
 fn main() -> NcResult<()> {
     // Init context
@@ -45,7 +49,10 @@ fn main() -> NcResult<()> {
     let mut selector_items: [NcSelectorItem; 11] = [
         NcSelectorItem::new("Afrikaans", "Ek kan glas eet, dit maak my nie seer nie."),
         NcSelectorItem::new("AngloSax", "ᛁᚳ᛫ᛗᚨᚷ᛫ᚷᛚᚨᛋ᛫ᛖᚩᛏᚪᚾ᛫ᚩᚾᛞ᛫ᚻᛁᛏ᛫ᚾᛖ᛫ᚻᛖᚪᚱᛗᛁᚪᚧ᛫ᛗᛖ᛬"),
-        NcSelectorItem::new("Japanese", "私はガラスを食べられます。それは私を傷つけません。"),
+        NcSelectorItem::new(
+            "Japanese",
+            "私はガラスを食べられます。それは私を傷つけません。",
+        ),
         NcSelectorItem::new("Kabuverdianu", "M’tá podê kumê vidru, ká stá máguame."),
         NcSelectorItem::new("Khmer", "ខ្ញុំអាចញុំកញ្ចក់បាន ដោយគ្មានបញ្ហារ"),
         NcSelectorItem::new("Lao", "ຂອ້ຍກິນແກ້ວໄດ້ໂດຍທີ່ມັນບໍ່ໄດ້ເຮັດໃຫ້ຂອ້ຍເຈັບ."),
@@ -75,7 +82,6 @@ fn main() -> NcResult<()> {
     stdplane.set_scrolling(true);
     stdplane.putstr_aligned(0, NcAlign::RIGHT, "selector widget demo")?;
 
-
     // Create selection plane
     // y: NcOffset, x: NcOffset, rows: NcDim, cols: NcDim
     let planeopts: NcPlaneOptions = NcPlaneOptions::new_aligned(1, NcAlign::LEFT, 15, 80);
@@ -88,11 +94,13 @@ fn main() -> NcResult<()> {
     let planeopts2: NcPlaneOptions = NcPlaneOptions::new_aligned(15, NcAlign::LEFT, 30, 80);
     let descplane: &mut NcPlane = NcPlane::with_options_bound(stdplane, planeopts2)?;
     descplane.set_scrolling(true);
-    descplane.puttext(0, NcAlign::LEFT,
+    descplane.puttext(
+        0,
+        NcAlign::LEFT,
         "Example of a selector widget:\n\
         -- Use the default mouse or arrow key to change selected line.\n\
         -- Or the customized J, K, TAB, SHIFT-TAB.\n\
-        -- Press ENTER (or Q) when satisfied with selection (or bored)."
+        -- Press ENTER (or Q) when satisfied with selection (or bored).",
     )?;
 
     // Render loop
@@ -118,7 +126,7 @@ fn run_selector(nc: &mut Nc, selector: &mut NcSelector) -> NcResult<String> {
     // Pre render <= do not wait input for first rendering
     nc.render()?;
 
-    loop{
+    loop {
         // Wait until user acts
         let keypress: char = nc.getc_blocking(Some(&mut ni))?;
 
@@ -133,20 +141,22 @@ fn run_selector(nc: &mut Nc, selector: &mut NcSelector) -> NcResult<String> {
                 // Q => quit
                 'q' | 'Q' | NcKey::ENTER => {
                     return Ok(selector.selected()?);
-                },
+                }
                 // J => down
                 'j' | 'J' => {
                     selector.nextitem()?;
-                },
+                }
                 // K => up
                 'k' | 'K' => {
                     selector.previtem()?;
-                },
+                }
                 // Tab => up or down depending if shift is pressed
-                '\u{0009}' => {
-                    match ni.shift {
-                        true => { selector.previtem()?; }
-                        false => { selector.nextitem()?; }
+                '\u{0009}' => match ni.shift {
+                    true => {
+                        selector.previtem()?;
+                    }
+                    false => {
+                        selector.nextitem()?;
                     }
                 },
                 // Default: ignore

--- a/examples/poc/examples/selector.rs
+++ b/examples/poc/examples/selector.rs
@@ -1,0 +1,160 @@
+//! Selector widget example
+//! Copied from: https://github.com/dankamongmen/notcurses/blob/master/src/poc/selector.c
+//!
+//! All types must be declared explicitely
+//! At all times, exactly one item is selected.
+//!
+//!
+//!01:                                                                        selector widget demo
+//!02: ╭───────────────────────────────────────────────────────────────────────╮
+//!03: │ this is truly, absolutely an awfully long example of a selector title │
+//!04: ╰─────┬──────────────────────────────pick one (you will die regardless)─┤
+//!05:       │             ↑                                                   │
+//!06:       │    Afrikaans Ek kan glas eet, dit maak my nie seer nie.         │
+//!07:       │     AngloSax ᛁᚳ᛫ᛗᚨᚷ᛫ᚷᛚᚨᛋ᛫ᛖᚩᛏᚪᚾ᛫ᚩᚾᛞ᛫ᚻᛁᛏ᛫ᚾᛖ᛫ᚻᛖᚪᚱᛗᛁᚪᚧ᛫ᛗᛖ᛬          │
+//!08:       │     Japanese 私はガラスを食べられます。それは私を傷つけません。 │
+//!09:       │ Kabuverdianu M’tá podê kumê vidru, ká stá máguame.              │
+//!10:       │        Khmer ខ្ញុំអាចញុំកញ្ចក់បាន ដោយគ្មានបញ្ហារ                         │
+//!11:       │          Lao ຂອ້ຍກິນແກ້ວໄດ້ໂດຍທີ່ມັນບໍ່ໄດ້ເຮັດໃຫ້ຂອ້ຍເຈັບ.                    │
+//!12:       │             ↓                                                   │
+//!13:       ╰──────────────────────────────press q to exit (there is no exit)─╯
+//!14:
+
+use libnotcurses_sys::{
+    // Core
+    Nc, NcResult,
+    // Plane
+    NcPlane, NcPlaneOptions,
+    // Input
+    NcInput, NcKey, NcEvType, NcAlign,
+};
+use libnotcurses_sys::*;  // Got a problem with NcAlign
+
+//// Selector:
+use libnotcurses_sys::widgets::{NcSelector, NcSelectorItem, NcSelectorOptions};
+
+
+fn main() -> NcResult<()> {
+    // Init context
+    let nc: &mut Nc = Nc::new()?;
+
+    // Enable mouse
+    nc.mouse_enable()?;
+
+    // Declare items of selector
+    let mut selector_items: [NcSelectorItem; 11] = [
+        NcSelectorItem::new("Afrikaans", "Ek kan glas eet, dit maak my nie seer nie."),
+        NcSelectorItem::new("AngloSax", "ᛁᚳ᛫ᛗᚨᚷ᛫ᚷᛚᚨᛋ᛫ᛖᚩᛏᚪᚾ᛫ᚩᚾᛞ᛫ᚻᛁᛏ᛫ᚾᛖ᛫ᚻᛖᚪᚱᛗᛁᚪᚧ᛫ᛗᛖ᛬"),
+        NcSelectorItem::new("Japanese", "私はガラスを食べられます。それは私を傷つけません。"),
+        NcSelectorItem::new("Kabuverdianu", "M’tá podê kumê vidru, ká stá máguame."),
+        NcSelectorItem::new("Khmer", "ខ្ញុំអាចញុំកញ្ចក់បាន ដោយគ្មានបញ្ហារ"),
+        NcSelectorItem::new("Lao", "ຂອ້ຍກິນແກ້ວໄດ້ໂດຍທີ່ມັນບໍ່ໄດ້ເຮັດໃຫ້ຂອ້ຍເຈັບ."),
+        NcSelectorItem::new("Russian", "Я могу есть стекло, оно мне не вредит."),
+        NcSelectorItem::new("Sanskrit", "kācaṃ śaknomyattum; nopahinasti mām."),
+        NcSelectorItem::new("Braille", "⠊⠀⠉⠁⠝⠀⠑⠁⠞⠀⠛⠇⠁⠎⠎⠀⠁⠝⠙⠀⠊⠞⠀⠙⠕⠑⠎⠝⠞⠀⠓⠥⠗⠞⠀⠍⠑"),
+        NcSelectorItem::new("Tibetan", "ཤེལ་སྒོ་ཟ་ནས་ང་ན་གི་མ་རེད།"),
+        NcSelectorItem::new_empty(),
+    ];
+
+    // Pack those items in the selector custom option struct
+    // -- with title, description and footer
+    let opts: NcSelectorOptions = NcSelectorOptions::new(
+        "this is truly, absolutely an awfully long example of a selector title",
+        "pick one (you will die regardless)",
+        "press q to exit (there is no exit)",
+        &mut selector_items,
+    );
+
+    // Create first plane (full screen)
+    let stdplane: &mut NcPlane = nc.stdplane();
+
+    // Set font color (green)
+    stdplane.set_fg_rgb(0x40f040);
+
+    // Set title
+    stdplane.set_scrolling(true);
+    stdplane.putstr_aligned(0, NcAlign::RIGHT, "selector widget demo")?;
+
+
+    // Create selection plane
+    // y: NcOffset, x: NcOffset, rows: NcDim, cols: NcDim
+    let planeopts: NcPlaneOptions = NcPlaneOptions::new_aligned(1, NcAlign::LEFT, 15, 80);
+    let selplane: &mut NcPlane = NcPlane::with_options_bound(stdplane, planeopts)?;
+
+    // Create selector
+    let selector: &mut NcSelector = NcSelector::new(selplane, opts)?;
+
+    // Create description plane
+    let planeopts2: NcPlaneOptions = NcPlaneOptions::new_aligned(15, NcAlign::LEFT, 30, 80);
+    let descplane: &mut NcPlane = NcPlane::with_options_bound(stdplane, planeopts2)?;
+    descplane.set_scrolling(true);
+    descplane.puttext(0, NcAlign::LEFT,
+        "Example of a selector widget:\n\
+        -- Use the default mouse or arrow key to change selected line.\n\
+        -- Or the customized J, K, TAB, SHIFT-TAB.\n\
+        -- Press ENTER (or Q) when satisfied with selection (or bored)."
+    )?;
+
+    // Render loop
+    let selected: String = run_selector(nc, selector)?;
+
+    // Destroy ressources
+    selector.destroy()?;
+
+    // Restore context, TERM status like cursor
+    nc.stop()?;
+
+    // Print solution, now the TERM is normal stdio
+    println!("You chose language: {}", &selected);
+
+    Ok(())
+}
+
+/// Helper to avoid having a render loop in the main function
+fn run_selector(nc: &mut Nc, selector: &mut NcSelector) -> NcResult<String> {
+    // Allocate input placeholder
+    let mut ni: NcInput = NcInput::new_empty();
+
+    // Pre render <= do not wait input for first rendering
+    nc.render()?;
+
+    loop{
+        // Wait until user acts
+        let keypress: char = nc.getc_blocking(Some(&mut ni))?;
+
+        if !selector.offer_input(ni) {
+            // Do not consider release key: only press
+            if ni.evtype == NcEvType::RELEASE {
+                continue;
+            }
+
+            // Act in function of key pressed
+            match keypress {
+                // Q => quit
+                'q' | 'Q' | NcKey::ENTER => {
+                    return Ok(selector.selected()?);
+                },
+                // J => down
+                'j' | 'J' => {
+                    selector.nextitem()?;
+                },
+                // K => up
+                'k' | 'K' => {
+                    selector.previtem()?;
+                },
+                // Tab => up or down depending if shift is pressed
+                '\u{0009}' => {
+                    match ni.shift {
+                        true => { selector.previtem()?; }
+                        false => { selector.nextitem()?; }
+                    }
+                },
+                // Default: ignore
+                _ => (),
+            }
+        }
+
+        // Render updated selector
+        nc.render()?;
+    }
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -368,7 +368,7 @@ macro_rules! error_str {
     ($str:expr, $msg:expr) => {
         if !$str.is_null() {
             #[allow(unused_unsafe)]
-            return Ok(unsafe { (&*$str).to_string() });
+            return Ok(unsafe { crate::rstring!($str).to_string() });
         } else {
             return Err(crate::NcError::with_msg(crate::c_api::NCRESULT_ERR, $msg));
         }

--- a/src/widgets/menu/methods/menu.rs
+++ b/src/widgets/menu/methods/menu.rs
@@ -163,7 +163,7 @@ impl NcMenu {
         }
         let res = unsafe { c_api::ncmenu_selected(self, ninput) };
         if !res.is_null() {
-            Some( rstring![&*res].to_string() )
+            Some(rstring![&*res].to_string())
         } else {
             None
         }

--- a/src/widgets/menu/methods/menu.rs
+++ b/src/widgets/menu/methods/menu.rs
@@ -2,7 +2,7 @@ use core::ptr::null_mut;
 
 use crate::{
     c_api::{self, ncmenu_create},
-    cstring, error, error_ref_mut, error_str,
+    cstring, error, error_ref_mut, error_str, rstring,
     widgets::{NcMenu, NcMenuOptions},
     NcInput, NcPlane, NcResult,
 };
@@ -163,7 +163,7 @@ impl NcMenu {
         }
         let res = unsafe { c_api::ncmenu_selected(self, ninput) };
         if !res.is_null() {
-            Some(unsafe { (&*res).to_string() })
+            Some( rstring![&*res].to_string() )
         } else {
             None
         }

--- a/src/widgets/selector/mod.rs
+++ b/src/widgets/selector/mod.rs
@@ -1,10 +1,142 @@
 //! `NcSelector` widget.
+//!                                 ╭──────────────────────────╮
+//!                                 │This is the primary header│
+//!   ╭──────────────────────this is the secondary header──────╮
+//!   │        ↑                                               │
+//!   │ option1 Long text #1                                   │
+//!   │ option2 Long text #2                                   │
+//!   │ option3 Long text #3                                   │
+//!   │ option4 Long text #4                                   │
+//!   │ option5 Long text #5                                   │
+//!   │ option6 Long text #6                                   │
+//!   │        ↓                                               │
+//!   ╰────────────────────────────────────here's the footer───╯
+//!
+//! selection widget -- an ncplane with a title header and a body section. the
+//! body section supports infinite scrolling up and down.
+//!
+//! At all times, exactly one item is selected.
 
-/// high-level widget for selecting one item from a set
+use core::ptr::null_mut;
+
+use crate::{
+    error_ref_mut, error_str, cstring_mut, cstring, error,
+    c_api::{ncselector_create, ncselector_destroy, ncselector_offer_input, ncselector_nextitem, ncselector_previtem, ncselector_selected, ncselector_additem, ncselector_delitem, ncselector_plane, },
+    NcInput, NcPlane, NcResult, NcChannels,
+};
+use crate::channel::*;
+
+
+/// High-level widget for selecting one item from a set
 pub type NcSelector = crate::bindings::ffi::ncselector;
 
-/// an item for [`NcSelector`]
+/// Item structure for [`NcSelector`]
 pub type NcSelectorItem = crate::bindings::ffi::ncselector_item;
 
-/// Options structur for [`NcSelector`]
+/// Options structure for [`NcSelector`]
 pub type NcSelectorOptions = crate::bindings::ffi::ncselector_options;
+
+/// # `NcSelector` constructors & destructors
+impl NcSelector {
+    pub fn new<'a>(plane: &mut NcPlane, options: NcSelectorOptions) -> NcResult<&'a mut Self> {
+        error_ref_mut![unsafe { ncselector_create(plane, &options) }, "Creating NcSelector"]
+    }
+
+    pub fn offer_input(&mut self, input: NcInput) -> bool {
+        unsafe { ncselector_offer_input(self, &input) }
+    }
+
+
+    /// Destroy the ncselector. If 'item' is not NULL, the last selected option will
+    /// be strdup()ed and assigned to '*item' (and must be free()d by the caller).
+    pub fn destroy(&mut self) -> NcResult<()> {
+        unsafe { ncselector_destroy(self, null_mut()) };
+        Ok(())
+    }
+
+
+    /// Dynamically add items. It is usually sufficient to supply a static
+    /// list of items via ncselector_options->items.
+    pub fn additem(&mut self, item: NcSelectorItem) -> NcResult<i32>{
+        error![unsafe { ncselector_additem(self, &item) }, "Calling selector.additem", -1 ]
+    }
+
+    /// Dynamically delete item
+    // TODO API int ncselector_delitem(struct ncselector* n, const char* item);
+    pub fn delitem(&mut self, item: &str) -> NcResult<i32>{
+        error![unsafe { ncselector_delitem(self, cstring![item]) }, "Calling selector.delitem", -1 ]
+    }
+
+    /// Return reference to the selected option, or NULL if there are no items.
+    pub fn selected(&mut self) -> NcResult<String> {
+        error_str![ unsafe { ncselector_selected(self) }, "Calling selector.selected" ]
+    }
+
+    /// Return a reference to the ncselector's underlying ncplane.
+    pub fn plane<'a>(&mut self) -> NcResult<&'a mut NcPlane> {
+        error_ref_mut![ unsafe { ncselector_plane(self) }, "Calling selector.plane" ]
+    }
+
+    /// Move down in the list. A reference to the newly-selected item is
+    /// returned, or NULL if there are no items in the list.
+    pub fn nextitem(&mut self) -> NcResult<String> {
+        let cstr: *const i8 = unsafe { ncselector_nextitem(self) };
+        error_str![ cstr, "Calling selector.nextitem"]
+    }
+
+    /// Move up in the list. A reference to the newly-selected item is
+    /// returned, or NULL if there are no items in the list.
+    pub fn previtem(&mut self) -> NcResult<String> {
+        let cstr: *const i8 = unsafe { ncselector_previtem(self) };
+        error_str![ cstr, "Calling selector.previtem"]
+    }
+}
+
+
+
+impl NcSelectorItem {
+    pub fn new(option: &str, desc: &str)-> Self {
+        Self {
+            option: cstring_mut![option],
+            desc: cstring_mut![desc],
+            opcolumns: 0,
+            desccolumns: 0,
+        }
+    }
+
+    /// New empty NcMenuItem for [`NcMenu`].
+    pub fn new_empty() -> Self {
+        Self {
+            option: null_mut(),
+            desc: null_mut(),
+            opcolumns: 0,
+            desccolumns: 0,
+        }
+    }
+}
+
+/// # `NcMenuOptions` constructors
+impl NcSelectorOptions {
+    /// New NcMenuOptions for [`NcMenu`].
+    ///
+    /// `sections` must contain at least 1 [`NcMenuSection`].
+    pub fn new(title: &str, secondary: &str, footer: &str, selector_item: &mut [NcSelectorItem]) -> Self {
+        //assert![!selector_item.is_empty()];
+        Self {
+            title: cstring_mut![title], // title may be null, inhibiting riser, saving two rows.
+            secondary: cstring_mut![secondary], // secondary may be null
+            footer: cstring_mut![footer], // footer may be null
+
+            items: selector_item.as_mut_ptr(), // initial items and descriptions
+            defidx: 1,
+            maxdisplay: 6, // maximum number of options to display at once, 0 to use all available space
+            // exhaustive styling options
+            opchannels: NcChannels::from_rgb8(0xe0, 0x80, 0x40, 0, 0, 0),
+            descchannels: NcChannels::from_rgb8(0x80, 0xe0, 0x40, 0, 0, 0),
+            titlechannels: NcChannels::from_rgb8(0xff, 0xff, 0x80, 0, 0, 0x20),
+            footchannels: NcChannels::from_rgb8(0xe0, 0, 0x40, 0x20, 0, 0),
+            boxchannels: NcChannels::from_rgb8(0x20, 0xe0, 0x40, 0x20, 0x20, 0x20),
+            flags: 0x0,
+        }
+    }
+}


### PR DESCRIPTION
Also:
* Move poc/example to poc/src/bin so that each file compiles by default.
* Fix the poc/menu description reporting: there was a mistake in string convention

Some quickstart could be added to the README like:
```bash
git clone https://github.com/dankamongmen/libnotcurses-sys; cd libnotcurses-sys
cd example/poc
cargo build
```
![notcurses_poc_screenshot](https://user-images.githubusercontent.com/6123962/136875567-3b10825f-1aef-48e6-970e-841f97857d86.png)