### PR TITLE
Remove serial_test_derive from deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ cty = "^0.2.1"
 
 [dev-dependencies]
 serial_test = "^0.5.1"
-serial_test_derive = "^0.5.1"
 
 # for the examples
 rand = "^0.8"


### PR DESCRIPTION
`serial_test` since [0.3](https://github.com/palfrey/serial_test/releases/tag/v0.3.0) includes `serial_test_derive` and lets you use the macro without needing to directly include `serial_test_derive`