### PR TITLE
fix `NcSelector.selected` returning always None

### DIFF
--- a/src/widgets/selector/methods.rs
+++ b/src/widgets/selector/methods.rs
@@ -74,9 +74,9 @@ impl NcSelector {
         // MAYBE turn this into a macro (option_str![])
         let res = unsafe { c_api::ncselector_selected(self) };
         if res.is_null() {
-            Some(crate::rstring!(res).to_string())
-        } else {
             None
+        } else {
+            Some(crate::rstring!(res).to_string())
         }
     }
 


### PR DESCRIPTION
Return values were flipped around.

I got to break my head for a while on why this wasn't working, then looked at the source code and thought _ah, that's why..._