### PR TITLE
Update bindgen dependency to v0.62

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ rand = "0.8"
 [build-dependencies]
 # https://tracker.debian.org/pkg/rust-bindgen
 # https://pkgs.org/search/?q=rust-bindgen
-bindgen = { version = "0.60", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.62", default-features = false, features = ["runtime"] }
 # https://tracker.debian.org/pkg/rust-pkg-config
 # https://pkgs.org/search/?q=rust-pkg-config
 pkg-config = "0.3.25"


### PR DESCRIPTION
libnotcurses-sys doesn't build on macos at the moment due to a clash between bindgen 0.60 and clang.  Updating to >= 0.62 resolves this.

For some more details:
https://github.com/rust-lang/rust-bindgen/issues/2312