### PR TITLE
fix: from_sixel incorrectly calls ncvisual_from_file instead of ncvisual_from_sixel

### DIFF
--- a/src/visual/methods.rs
+++ b/src/visual/methods.rs
@@ -103,7 +103,7 @@ impl NcVisual {
     pub fn from_sixel<'a>(sequence: &str, len_y: u32, len_x: u32) -> NcResult<&'a mut NcVisual> {
         let cs = cstring![sequence];
         error_ref_mut![
-            unsafe { c_api::ncvisual_from_file(cs.as_ptr()) },
+            unsafe { c_api::ncvisual_from_sixel(cs.as_ptr(), len_y, len_x) },
             &format!("NcVisual::from_sixel({}, {}, {})", sequence, len_y, len_x)
         ]
     }


### PR DESCRIPTION
there's a bug in the c api that results in `ncvisual_from_file` being called instead of `ncvisual_from_sixel`